### PR TITLE
fix URL (BitZeny 1.2.1 to 2.0.0)

### DIFF
--- a/en.html
+++ b/en.html
@@ -199,9 +199,9 @@
                     <ul class="l-text_center o-w600 u-p16 u-m0a u-font_sans">
                         <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Release note</a></li>
                         <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny"><i class="fa fa-file-archive-o" aria-hidden="true"></i> Source Code</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-osx.dmg"><i class="fa fa-apple" aria-hidden="true"></i> bitzeny-1.2.1-osx.dmg</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-win32-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-1.2.1-win32-setup.exe</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-win64-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-1.2.1-win64-setup.exe</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-osx-unsigned.dmg"><i class="fa fa-apple" aria-hidden="true"></i> bitzeny-2.0.0-osx-unsigned.dmg</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win32-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win32-setup.exe</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win64-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win64-setup.exe</a></li>
                     </ul>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -165,11 +165,11 @@
                 </div>
                 <div class="l-flex_justify_center l-flex_wrap o-w100per u-pb160">
                     <div class="l-text_center u-plr8">
-                        <p><span>BitZenyの最大の特徴は普通のPCで</span><span>CPUマイニングができる点です。</span><br>
-                            <span>多くの仮想通貨はGPUやASICを使って</span><span>マイニングされているため、</span><br>
-                            <span>専用機器に投資できる</span><span>一部のマイナーによる寡占状態となります。</span><br>
+                        <p><span>BitZenyの最大の特徴は普通のPCでCPUマイニングができる点です。</span><br>
+                            <span>多くの仮想通貨はGPUやASICを使ってマイニングされているため、</span><br>
+                            <span>専用機器に投資できる一部のマイナーによる寡占状態となります。</span><br>
                             <span>BitZenyはGPUやASICでの採掘が難しく、</span><br>
-                            <span>CPUマイニングに適したアルゴリズムを</span><span>採用しています。</span></p>
+                            <span>CPUマイニングに適したアルゴリズムを採用しています。</span></p>
                     </div>
                 </div>
                 <div class="o-w100per u-mb16">
@@ -178,7 +178,7 @@
                 <div class="l-flex_justify_center l-flex_wrap o-w100per u-pb160">
                     <div class="l-text_center u-plr8">
                         <p><span>CPUマイニングによって個人でも利益が生み出せる構造のため、</span><br>
-                            <span>BitZenyのコミュニティは</span><span>マイナーによる賑わいを見せています。</span><br>
+                            <span>BitZenyのコミュニティはマイナーによる賑わいを見せています。</span><br>
                             <span>また、「ぜにぃ姫」やBitZeny決済可能な飲食店などをはじめとし、</span><br>
                             <span>BitZenyに関する様々な機能やサービスが次々開発されており、</span><br>
                             <span>マイナーのみならずホルダーも楽しめる世界が広がりつつあります。</span></p>
@@ -191,8 +191,8 @@
                     <div class="l-text_center u-plr8">
                         <p><span>BitZenyの歴史は2014年11月に遡ります。</span><br>
                             <span>だれでも手軽にマイニングできる暗号通貨を目指し</span><br>
-                            <span>Bitcoinのクローンとして</span><span>日本国内の開発者によって誕生しました。</span><br>
-                            <span>通貨単位はZNY、</span><span>総発行枚数は2億5千万枚と上限があります。</span><br>
+                            <span>Bitcoinのクローンとして日本国内の開発者によって誕生しました。</span><br>
+                            <span>通貨単位はZNY、総発行枚数は2億5千万枚と上限があります。</span><br>
                         </p>
                     </div>
                 </div>
@@ -208,9 +208,9 @@
                     <ul class="l-text_center o-w600 u-p16 u-m0a u-font_sans">
                         <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Release note</a></li>
                         <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny"><i class="fa fa-file-archive-o" aria-hidden="true"></i> Source Code</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-osx.dmg"><i class="fa fa-apple" aria-hidden="true"></i> bitzeny-1.2.1-osx.dmg</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-win32-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-1.2.1-win32-setup.exe</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z1.2.1/bitzeny-1.2.1-win64-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-1.2.1-win64-setup.exe</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-osx-unsigned.dmg"><i class="fa fa-apple" aria-hidden="true"></i> bitzeny-2.0.0-osx-unsigned.dmg</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win32-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win32-setup.exe</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win64-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win64-setup.exe</a></li>
                     </ul>
                 </div>
             </div>
@@ -223,7 +223,7 @@
                 </div>
                 <div class="l-flex_justify_center l-flex_wrap o-w100per">
                     <div class="l-text_center u-plr8">
-                        <p><span>BitZeny</span><span>経済圏の</span><span>成熟とともに</span><span>人々の生活に</span><span>定着させ、</span><br><span>活気のある</span><span>社会を</span><span>醸成します。</span></p>
+                        <p><span>BitZeny経済圏の成熟とともに人々の生活に定着させ、</span><br><span>活気のある社会を醸成します。</span></p>
                     </div>
                 </div>
             </div>

--- a/nl.html
+++ b/nl.html
@@ -194,7 +194,10 @@
                 <div class="o-w100per l-flex_justify_center l-flex_wrap">
                     <ul class="l-text_center o-w600 u-p16 u-m0a u-font_sans">
                         <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Release note</a></li>
-                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny"><i class="fa fa-file-archive-o" aria-hidden="true"></i> Source Code</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color4 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny"><i class="fa fa-file-archive-o" aria-hidden="true"></i> Source Code</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color2 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-osx-unsigned.dmg"><i class="fa fa-apple" aria-hidden="true"></i> bitzeny-2.0.0-osx-unsigned.dmg</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win32-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win32-setup.exe</a></li>
+                        <li><a class="o-w100per u-p16 u-mb16 u-color1 u-font_white u-iconize-round" href="https://github.com/BitzenyCoreDevelopers/bitzeny/releases/download/z2.0.0a/bitzeny-2.0.0-win64-setup.exe"><i class="fa fa fa-windows" aria-hidden="true"></i> bitzeny-2.0.0-win64-setup.exe</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
BitZenyが~~1.3.0~~2.0.0に更新されましたので、それに応じて更新をかけた次第です。
1.3.1まで待つのでしたらこのプルリクで続けます。
また、一部謎spanが入ってましたので、それも消しています（レスポンス状態にした時点で挙動が変わらないことは確認済みです）

EDIT: マージ後に名前間違いに気づきましたが、1.3.0じゃなくて2.0.0でした…すみません。