### PR TITLE
リンクからjamBTCを削除、Cryptopiaを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,10 +345,10 @@
                         <div class="o-w33per o-link_h u-mb30">
                             <div class="l-flex_direction_center l-flex_justify_sb l-text_center o-h100per u-m16 u-bg_gray u-font_gray">
                                 <div class="u-p16 u-pb0">
-                                    <h3>Jambtc</h3> <a href="https://join.slack.com/t/jambtc/shared_invite/enQtMjkwODc5MTcxMjUwLTc2NTIyOWRiZDI5YjgwYzNkMjJkMThlNzUxNmJlNmYxZTNiNjRlMDY2YzFlMGMxMjM2YmE4OGM0MmZkM2FjNWE" class="u-m8 u-color1 u-iconize-round u-font_white u-font_bold u-font_small" target="_blank"><i class="fa fa-twitter twitter u-plr4" aria-hidden="true"></i>管理者</a>
-                                    <p class="u-font_small u-pt14">中国に拠点をおくCEX。MONAやZNYなどが取引できます。</p>
+                                    <h3>Cryptopia</h3> <a href="https://twitter.com/Cryptopia_NZ" class="u-m8 u-color1 u-iconize-round u-font_white u-font_bold u-font_small" target="_blank"><i class="fa fa-twitter twitter u-plr4" aria-hidden="true"></i>管理者</a>
+                                    <p class="u-font_small u-pt14">ニュージーランドの取引所です。BitZenyをBTCやLTCなどと取引できます。</p>
                                 </div>
-                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://jambtc.com/" target="_blank">Jambtc</a>
+                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://www.cryptopia.co.nz/" target="_blank">Cryptopia</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
jamBTCが消滅したため、リンクから削除しました。
また、Cryptopiaに上場したため、追加しました。