### PR TITLE
サイト説明の内容変更、サイト名変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-    <meta name="description" content="BitZenyはデバイスを選ばない共有システムをもつ。それはかつてない感動と、これまでにない価値をあなたに与えてくれるだろう。" />
+    <meta name="description" content="BitZeny.tech――CPUマイニングで誰でも手軽に入手できる日本発の仮想通貨、BitZenyの新公式サイト" />
     <meta name="keywords" content="BitZeny,ビットゼニー,暗号通貨,仮想通貨,マイニング" />
 
     <meta property="og:locale" content="ja_JP">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://bitzeny.tech/">
     <meta property="og:image" content="https://bitzeny.tech/img/og_img.png">
-    <meta property="og:site_name" content="BitZeny Project">
-    <meta property="og:title" content="BitZeny Project">
-    <meta property="og:description" content="BitZenyはデバイスを選ばない共有システムをもつ。それはかつてない感動と、これまでにない価値をあなたに与えてくれるだろう。">
+    <meta property="og:site_name" content="BitZeny.tech">
+    <meta property="og:title" content="BitZeny.tech">
+    <meta property="og:description" content="BitZeny.tech――CPUマイニングで誰でも手軽に入手できる日本発の仮想通貨、BitZenyの新公式サイト">
 
-    <title>BitZeny Project</title>
+    <title>BitZeny.tech</title>
 
     <link rel="icon" href="img/bitzeny.ico">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/minireset.css/0.0.2/minireset.min.css" integrity="sha256-5Co4VU8G29ti556RmwtiyF2G2De1jHI3XnJh66vGpRI=" crossorigin="anonymous" />


### PR DESCRIPTION
[こちらのissueで](https://github.com/BitzenyCoreDevelopers/others/issues/32 )
新公式サイトがBitZeny.techであると決定したため、サイト説明の変更及び、サイト名称の変更を行いました
descriptionの内容変更
新公式サイトであるということが分かる文面に

BitZenyはデバイスを選ばない共有システムをもつ。それはかつてない感動と、これまでにない価値をあなたに与えてくれるだろう。
↓
BitZeny.tech――CPUマイニングで誰でも手軽に入手できる日本発の仮想通貨、BitZenyの新公式サイト

サイトタイトルの変更
日常的に.techと呼ばれていたので変更しました
旧公式サイトとも差別化が図れるかと

BitZeny Project
↓
BitZeny.tech