### PR TITLE
Fix links JamBTC and Cryptopia in English page

### DIFF
--- a/en.html
+++ b/en.html
@@ -344,10 +344,10 @@
                         <div class="o-w33per o-link_h u-mb30">
                             <div class="l-flex_direction_center l-flex_justify_sb l-text_center o-h100per u-m16 u-bg_gray u-font_gray">
                                 <div class="u-p16 u-pb0">
-                                    <h3>Jambtc</h3> <a href="https://join.slack.com/t/jambtc/shared_invite/enQtMjkwODc5MTcxMjUwLTc2NTIyOWRiZDI5YjgwYzNkMjJkMThlNzUxNmJlNmYxZTNiNjRlMDY2YzFlMGMxMjM2YmE4OGM0MmZkM2FjNWE" class="u-m8 u-color1 u-iconize-round u-font_white u-font_bold u-font_small" target="_blank"><i class="fa fa-twitter twitter u-plr4" aria-hidden="true"></i>Manager</a>
-                                    <p class="u-font_small u-pt14">CEX based in China. You can trade MONA and ZNY etc.</p>
+                                    <h3>Cryptopia</h3> <a href="https://twitter.com/Cryptopia_NZ" class="u-m8 u-color1 u-iconize-round u-font_white u-font_bold u-font_small" target="_blank"><i class="fa fa-twitter twitter u-plr4" aria-hidden="true"></i>Manager</a>
+                                    <p class="u-font_small u-pt14">An Exchange in New Zealand.You can buy BitZeny by BTC and LTC,DOGE.</p>
                                 </div>
-                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://jambtc.com/" target="_blank">Jambtc</a>
+                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-fongt_white" href="https://www.cryptopia.co.nz" target="_blank">Cryptopia</a>
                                 </div>
                             </div>
                         </div>

--- a/en.html
+++ b/en.html
@@ -347,7 +347,7 @@
                                     <h3>Cryptopia</h3> <a href="https://twitter.com/Cryptopia_NZ" class="u-m8 u-color1 u-iconize-round u-font_white u-font_bold u-font_small" target="_blank"><i class="fa fa-twitter twitter u-plr4" aria-hidden="true"></i>Manager</a>
                                     <p class="u-font_small u-pt14">An Exchange in New Zealand.You can buy BitZeny by BTC and LTC,DOGE.</p>
                                 </div>
-                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-fongt_white" href="https://www.cryptopia.co.nz" target="_blank">Cryptopia</a>
+                                <div class="u-p16 u-pt0"><a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://www.cryptopia.co.nz" target="_blank">Cryptopia</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
jamBTCが消滅したため、英語版のリンクから削除しました。
また、Cryptopiaに上場したため、英語版に追加しました。
**英語版での修正忘れてました。**