### PR TITLE
fix 暗号通貨BitZenyまとめwiki link

### DIFF
--- a/en.html
+++ b/en.html
@@ -285,7 +285,7 @@
                                     <p class="u-font_small u-pt14">It's comprehensively transmitting about News relating BitZeny, How to start, information for Project, community, engineer.</p>
                                 </div>
                                 <div class="u-p16 u-pt0">
-                                    <a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="http://bitzeny.cswiki.jp/" target="_blank">BitZeny Wiki</a></div>
+                                    <a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://bitzeny.wiki.fc2.com/" target="_blank">BitZeny Wiki</a></div>
                             </div>
                         </div>
                         <div class="o-w33per o-link_h u-mb30">
@@ -382,7 +382,7 @@
                 <div class="l-flex_justify_sb u-font_bold">
                     <a class="u-m8 u-font_small u-font_white" href="https://github.com/BitzenyCoreDevelopers" target="_blank">GitHub</a>
                     <a class="u-m8 u-font_small u-font_white" href="https://bitcointalk.org/index.php?topic=849994.0" target="_blank">Bitcoin Forum</a>
-                    <a class="u-m8 u-font_small u-font_white" href="http://bitzeny.cswiki.jp/" target="_blank">Wiki</a>
+                    <a class="u-m8 u-font_small u-font_white" href="https://bitzeny.wiki.fc2.com/" target="_blank">Wiki</a>
                 </div>
             </div>
             <p class="l-text_center o-w100per u-pb160 u-font_small">Copyright © 2018 BitZeny Project. All Rights Reserved.</p>

--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
                                     <p class="u-font_small u-pt14">BitZeny関連のニュースや導入方法をはじめ、企画・コミュニティ・技術者向け情報などを総合的に発信しています。</p>
                                 </div>
                                 <div class="u-p16 u-pt0">
-                                    <a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="http://bitzeny.cswiki.jp/" target="_blank">暗号通貨BitZenyまとめWiki</a></div>
+                                    <a class="o-w100per u-color2 u-iconize-square u-font_small u-font_bold u-font_white" href="https://bitzeny.wiki.fc2.com/" target="_blank">暗号通貨BitZenyまとめWiki</a></div>
                             </div>
                         </div>
                         <div class="o-w33per o-link_h u-mb30">
@@ -395,7 +395,7 @@
                 <div class="l-flex_justify_sb u-font_bold">
                     <a class="u-m8 u-font_small u-font_white" href="https://github.com/BitzenyCoreDevelopers" target="_blank">GitHub</a>
                     <a class="u-m8 u-font_small u-font_white" href="https://bitcointalk.org/index.php?topic=849994.0" target="_blank">Bitcoin Forum</a>
-                    <a class="u-m8 u-font_small u-font_white" href="http://bitzeny.cswiki.jp/" target="_blank">Wiki</a>
+                    <a class="u-m8 u-font_small u-font_white" href="https://bitzeny.wiki.fc2.com/" target="_blank">Wiki</a>
                 </div>
             </div>
             <p class="l-text_center o-w100per u-pb160 u-font_small">Copyright © 2017-2018 BitZeny Project. All Rights Reserved.</p>


### PR DESCRIPTION
まとめwiki移転とのことでURLを変更しました
フッター部のWikiのリンク、英語版ファイルも対応済みです